### PR TITLE
Use `got`, add `maxRetry` and `timeout` options

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,8 +47,10 @@ OPTIONS
   -h, --help                Show this help message
   -i, --increment           Enable increment mode. Default: false
   -n, --name=<filename>     The filename. Default: original filename or timestamp
+      --max-retry=<number>  Set the maximum number of times to retry the request if it fails
       --silent              Disable logging
       --start=<number>      The start index for increment mode. Default: 0
+  -t, --timeout=<number>    Set timeout for each request in milliseconds
   -v, --version             Show the version number
 
 EXAMPLES
@@ -133,5 +135,7 @@ Required: `false`
 | `options.directory` | `string` | `process.cwd()` | The output directory |
 | `options.extension` | `string` | `'jpg'` | The file extension. If not specified, the original extension will be used. If the original extension is not available, `'jpg'` will be used. |
 | `options.name` | `string` | `'image'` | The filename. If not specified, the original filename will be used. If the original filename is not available, `'image'` will be used. <br>When downloading multiple images, `-index` will be appended to the end of the name (suffix). `index` will start from 1. For example: `image-1` |
+| `options.maxRetry` | `number` | `2` | Set the maximum number of times to retry the request if it fails.
 | `options.onSuccess` | `(image: Image) => void` | `undefined` | The callback function to be called when the image is successfully downloaded. Only available when downloading multiple images. |
 | `options.onError` | `(error: Error, url: string) => void` | `undefined` | The callback function to be called when the image fails to download. Only available when downloading multiple images. |
+| `options.timeout` | `number` | `undefined` | Set timeout for each request in milliseconds.

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "cli-progress": "^3.12.0",
+        "got": "^13.0.0",
         "meow": "^12.1.1",
         "sanitize-filename": "^1.6.3"
       },
@@ -612,6 +613,28 @@
       "integrity": "sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==",
       "dev": true
     },
+    "node_modules/@sindresorhus/is": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-5.6.0.tgz",
+      "integrity": "sha512-TV7t8GKYaJWsn00tFDqBw8+Uqmr8A0fRU1tvTQhyZzGv0sJCGRQL3JGMI3ucuKo3XIZdUP+Lx7/gh2t3lewy7g==",
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/is?sponsor=1"
+      }
+    },
+    "node_modules/@szmarczak/http-timer": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-5.0.1.tgz",
+      "integrity": "sha512-+PmQX0PiAYPMeVYe237LJAYvOMYW1j2rH5YROyS3b4CTVJum34HfRvKvAzozHAQG0TnHNdUfY9nCeUyRAs//cw==",
+      "dependencies": {
+        "defer-to-connect": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=14.16"
+      }
+    },
     "node_modules/@types/chai": {
       "version": "4.3.9",
       "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.3.9.tgz",
@@ -635,6 +658,11 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/http-cache-semantics": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.0.3.tgz",
+      "integrity": "sha512-V46MYLFp08Wf2mmaBhvgjStM3tPa+2GAdy/iqoX+noX1//zje2x4XmrIU0cAwyClATsTmahbtoQ2EwP7I5WSiA=="
     },
     "node_modules/@types/istanbul-lib-coverage": {
       "version": "2.0.5",
@@ -1246,6 +1274,42 @@
         "node": ">=8"
       }
     },
+    "node_modules/cacheable-lookup": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/cacheable-lookup/-/cacheable-lookup-7.0.0.tgz",
+      "integrity": "sha512-+qJyx4xiKra8mZrcwhjMRMUhD5NR1R8esPkzIYxX96JiecFoxAXFuz/GpR3+ev4PE1WamHip78wV0vcmPQtp8w==",
+      "engines": {
+        "node": ">=14.16"
+      }
+    },
+    "node_modules/cacheable-request": {
+      "version": "10.2.14",
+      "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-10.2.14.tgz",
+      "integrity": "sha512-zkDT5WAF4hSSoUgyfg5tFIxz8XQK+25W/TLVojJTMKBaxevLBBtLxgqguAuVQB8PVW79FVjHcU+GJ9tVbDZ9mQ==",
+      "dependencies": {
+        "@types/http-cache-semantics": "^4.0.2",
+        "get-stream": "^6.0.1",
+        "http-cache-semantics": "^4.1.1",
+        "keyv": "^4.5.3",
+        "mimic-response": "^4.0.0",
+        "normalize-url": "^8.0.0",
+        "responselike": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=14.16"
+      }
+    },
+    "node_modules/cacheable-request/node_modules/get-stream": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
+      "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/call-bind": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
@@ -1443,6 +1507,31 @@
         }
       }
     },
+    "node_modules/decompress-response": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+      "dependencies": {
+        "mimic-response": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/decompress-response/node_modules/mimic-response": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/deep-eql": {
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-4.1.3.tgz",
@@ -1460,6 +1549,14 @@
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true
+    },
+    "node_modules/defer-to-connect": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-2.0.1.tgz",
+      "integrity": "sha512-4tvttepXG1VaYGrRibk5EwJd1t4udunSOVMdLSAL6mId1ix438oPwPZMALY41FCijukO1L0twNcGsdzS7dHgDg==",
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/define-data-property": {
       "version": "1.1.1",
@@ -2119,6 +2216,14 @@
         "is-callable": "^1.1.3"
       }
     },
+    "node_modules/form-data-encoder": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/form-data-encoder/-/form-data-encoder-2.1.4.tgz",
+      "integrity": "sha512-yDYSgNMraqvnxiEXO4hi88+YZxaHC6QKzb5N84iRCTDeRO7ZALpir/lVmf/uXUhnwUr2O4HU8s/n6x+yNjQkHw==",
+      "engines": {
+        "node": ">= 14.17"
+      }
+    },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -2321,6 +2426,41 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/got": {
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/got/-/got-13.0.0.tgz",
+      "integrity": "sha512-XfBk1CxOOScDcMr9O1yKkNaQyy865NbYs+F7dr4H0LZMVgCj2Le59k6PqbNHoL5ToeaEQUYh6c6yMfVcc6SJxA==",
+      "dependencies": {
+        "@sindresorhus/is": "^5.2.0",
+        "@szmarczak/http-timer": "^5.0.1",
+        "cacheable-lookup": "^7.0.0",
+        "cacheable-request": "^10.2.8",
+        "decompress-response": "^6.0.0",
+        "form-data-encoder": "^2.1.2",
+        "get-stream": "^6.0.1",
+        "http2-wrapper": "^2.1.10",
+        "lowercase-keys": "^3.0.0",
+        "p-cancelable": "^3.0.0",
+        "responselike": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/got?sponsor=1"
+      }
+    },
+    "node_modules/got/node_modules/get-stream": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
+      "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/graphemer": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
@@ -2410,6 +2550,23 @@
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
       "dev": true
+    },
+    "node_modules/http-cache-semantics": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.1.tgz",
+      "integrity": "sha512-er295DKPVsV82j5kw1Gjt+ADA/XYHsajl82cGNQG2eyoPkvgUhX+nDIyelzhIWbbsXP39EHcI6l5tYs2FYqYXQ=="
+    },
+    "node_modules/http2-wrapper": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/http2-wrapper/-/http2-wrapper-2.2.0.tgz",
+      "integrity": "sha512-kZB0wxMo0sh1PehyjJUWRFEd99KC5TLjZ2cULC4f9iqJBAmKQQXEICjxl5iPJRwP40dpeHFqqhm7tYCvODpqpQ==",
+      "dependencies": {
+        "quick-lru": "^5.1.1",
+        "resolve-alpn": "^1.2.0"
+      },
+      "engines": {
+        "node": ">=10.19.0"
+      }
     },
     "node_modules/human-signals": {
       "version": "5.0.0",
@@ -2853,8 +3010,7 @@
     "node_modules/json-buffer": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
-      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
-      "dev": true
+      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ=="
     },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
@@ -2891,7 +3047,6 @@
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
       "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
-      "dev": true,
       "dependencies": {
         "json-buffer": "3.0.1"
       }
@@ -2979,6 +3134,17 @@
       "dev": true,
       "dependencies": {
         "get-func-name": "^2.0.1"
+      }
+    },
+    "node_modules/lowercase-keys": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-3.0.0.tgz",
+      "integrity": "sha512-ozCC6gdQ+glXOQsveKD0YsDy8DSQFjDTz4zyzEHNV5+JP5D62LmfDZ6o1cycFx9ouG940M5dE8C8CTewdj2YWQ==",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/lru-cache": {
@@ -3071,6 +3237,17 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/mimic-response": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-4.0.0.tgz",
+      "integrity": "sha512-e5ISH9xMYU0DzrT+jl8q2ze9D6eWBto+I8CNpe+VI+K2J/F/k3PdkdTdz4wvGVH4NTpo+NRYTVIuMQEMMcsLqg==",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/minimatch": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
@@ -3153,6 +3330,17 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/normalize-url": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-8.0.0.tgz",
+      "integrity": "sha512-uVFpKhj5MheNBJRTiMZ9pE/7hD1QTeEvugSJW/OmLzAp78PB5O6adfMNTvmfKhXBkvCzC+rqifWcVYpGFwTjnw==",
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/npm-run-path": {
@@ -3329,6 +3517,14 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/p-cancelable": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-3.0.0.tgz",
+      "integrity": "sha512-mlVgR3PGuzlo0MmTdk4cXqXWlwQDLnONTAg6sm62XkMJEiRxN3GL3SffkYvqwonbkJBcrI7Uvv5Zh9yjvn2iUw==",
+      "engines": {
+        "node": ">=12.20"
       }
     },
     "node_modules/p-limit": {
@@ -3605,6 +3801,17 @@
         }
       ]
     },
+    "node_modules/quick-lru": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz",
+      "integrity": "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/react-is": {
       "version": "18.2.0",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
@@ -3658,6 +3865,11 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/resolve-alpn": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/resolve-alpn/-/resolve-alpn-1.2.1.tgz",
+      "integrity": "sha512-0a1F4l73/ZFZOakJnQ3FvkJ2+gSTQWz/r2KE5OdDY0TxPm5h4GkqkWWfM47T7HsbnOtcJVEF4epCVy6u7Q3K+g=="
+    },
     "node_modules/resolve-from": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
@@ -3665,6 +3877,20 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/responselike": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/responselike/-/responselike-3.0.0.tgz",
+      "integrity": "sha512-40yHxbNcl2+rzXvZuVkrYohathsSJlMTXKryG5y8uciHv1+xDLHQpgjG64JUO9nrEq2jGLH6IZ8BcZyw3wrweg==",
+      "dependencies": {
+        "lowercase-keys": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/reusify": {

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
   },
   "dependencies": {
     "cli-progress": "^3.12.0",
+    "got": "^13.0.0",
     "meow": "^12.1.1",
     "sanitize-filename": "^1.6.3"
   }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -24,8 +24,10 @@ const cli = meow(`
     -h, --help                Show this help message
     -i, --increment           Enable increment mode. Default: false
     -n, --name=<filename>     The filename. Default: original filename or timestamp
+        --max-retry=<number>  Set the maximum number of times to retry the request if it fails
         --silent              Disable logging
         --start=<number>      The start index for increment mode. Default: 0
+    -t, --timeout=<number>    Set timeout for each request in milliseconds
     -v, --version             Show the version number
 
   EXAMPLES
@@ -61,8 +63,15 @@ const cli = meow(`
       shortFlag: 'n',
       type: 'string',
     },
+    maxRetry: {
+      type: 'number',
+    },
     silent: {
       type: 'boolean',
+    },
+    timeout: {
+      shortFlag: 't',
+      type: 'number',
     },
   },
 });
@@ -142,6 +151,8 @@ async function main() {
         `${new Date().toISOString()} failed download from ${url}, ${error.name}: ${error.message}\n`,
       );
     },
+    maxRetry: flags.maxRetry,
+    timeout: flags.timeout,
   });
 
   if (!flags.silent) {

--- a/src/downloader.ts
+++ b/src/downloader.ts
@@ -1,11 +1,11 @@
+import got, { PlainResponse } from 'got';
 import fs from 'node:fs';
 import path from 'node:path';
 import { pipeline } from 'node:stream/promises';
 import sanitize from 'sanitize-filename';
+import { DEFAULT_EXTENSION, DEFAULT_NAME, imageExtensions } from './constanta.js';
 import ArgumentError from './errors/ArgumentError.js';
 import DirectoryError from './errors/DirectoryError.js';
-import FetchError from './errors/FetchError.js';
-import { DEFAULT_EXTENSION, DEFAULT_NAME, imageExtensions } from './constanta.js';
 import { Image } from './index.js';
 
 export type DownloadOptions = {
@@ -109,65 +109,46 @@ export function parseImageParams(url: string, options?: DownloadOptions) {
  * @param options The options to use.
  * @returns The file path.
  * @throws {DirectoryError} If the directory cannot be created.
- * @throws {FetchError} If the URL is invalid or the response is unsuccessful.
+ * @throws {Error} If there are any other errors.
  */
 export async function download(url: string, options: DownloadOptions = {}) {
   const img = parseImageParams(url, options);
 
-  try {
-    // Create the directory if it doesn't exist.
-    if (!fs.existsSync(img.directory)) {
+  // Create the directory if it doesn't exist.
+  if (!fs.existsSync(img.directory)) {
+    try {
       fs.mkdirSync(img.directory, { recursive: true });
-    }
-  } catch (error) {
-    if (error instanceof Error) {
-      if (error.message.includes('EACCES')) {
-        throw new DirectoryError(`Permission denied to create '${img.directory}'`);
+    } catch (error) {
+      if (error instanceof Error) {
+        throw new DirectoryError(error.message);
       }
-      throw new DirectoryError(error.message);
-    } else {
       throw new DirectoryError(`Failed to create '${img.directory}'`);
     }
   }
 
-  let response: Response;
+  return new Promise<Image>((resolve, reject) => {
+    const fetchStream = got.stream(img.url);
 
-  try {
-    response = await fetch(url);
-  } catch (error) {
-    if (error instanceof Error) {
-      throw new FetchError(error.message);
-    } else {
-      throw new FetchError('Failed to fetch image');
-    }
-  }
+    const onError = (error: unknown) => {
+      reject(error);
+    };
 
-  if (!response.ok) {
-    throw new FetchError(`Unsuccessful response: ${response.status} ${response.statusText}`);
-  }
-
-  if (response.body === null) {
-    throw new FetchError('Response body is null');
-  }
-
-  // Ensure the response is an image
-  const contentType = response.headers.get('content-type');
-  if (!contentType || !contentType.startsWith('image/')) {
-    throw new FetchError('The response is not an image.');
-  }
-
-  try {
-    await pipeline(response.body, fs.createWriteStream(img.path));
-  } catch (error) {
-    if (error instanceof Error) {
-      if (error.message.includes('EACCES')) {
-        throw new DirectoryError(`Permission denied to save image in '${img.directory}'`);
+    fetchStream.on('response', (res: PlainResponse) => {
+      // Ensure the response is an image
+      const contentType = res.headers['content-type'];
+      if (!contentType || !contentType.startsWith('image/')) {
+        fetchStream.destroy(new Error('The response is not an image.'));
+        return;
       }
-      throw new DirectoryError(error.message);
-    } else {
-      throw new DirectoryError(`Failed to save image in '${img.directory}'`);
-    }
-  }
 
-  return img;
+      // Prevent `onError` being called twice.
+      fetchStream.off('error', onError);
+
+      pipeline(fetchStream, fs.createWriteStream(img.path))
+        .then(() => { resolve(img); }) // Return the image data.
+        .catch((error) => { onError(error); });
+    });
+
+    fetchStream.once('error', onError);
+  });
 }

--- a/src/downloader.ts
+++ b/src/downloader.ts
@@ -28,6 +28,12 @@ export type DownloadOptions = {
    */
   name?: string | ((original?: string) => string);
   /**
+   * Set the maximum number of times to retry the request if it fails.
+   *
+   * @default 2
+   */
+  maxRetry?: number;
+  /**
    * The extension of the image.
    *
    * If not provided, the extension of the URL will be used.
@@ -35,6 +41,10 @@ export type DownloadOptions = {
    * If the URL doesn't have an extension, `jpg` will be used.
    */
   extension?: string;
+  /**
+   * Set timeout for each request in milliseconds.
+   */
+  timeout?: number;
 };
 
 /**
@@ -127,7 +137,14 @@ export async function download(url: string, options: DownloadOptions = {}) {
   }
 
   return new Promise<Image>((resolve, reject) => {
-    const fetchStream = got.stream(img.url);
+    const fetchStream = got.stream(img.url, {
+      timeout: {
+        request: options.timeout,
+      },
+      retry: {
+        limit: options.maxRetry,
+      },
+    });
 
     const onError = (error: unknown) => {
       reject(error);

--- a/src/errors/FetchError.ts
+++ b/src/errors/FetchError.ts
@@ -1,6 +1,0 @@
-export default class FetchError extends Error {
-  constructor(message: string) {
-    super(message);
-    this.name = 'FetchError';
-  }
-}

--- a/test/downloader.spec.ts
+++ b/test/downloader.spec.ts
@@ -1,10 +1,10 @@
+import { HTTPError, RequestError } from 'got';
 import fs from 'node:fs';
 import { describe, expect, test } from 'vitest';
 import { DEFAULT_EXTENSION, DEFAULT_NAME } from '~/constanta.js';
 import { download, parseImageParams } from '~/downloader.js';
 import ArgumentError from '~/errors/ArgumentError.js';
 import DirectoryError from '~/errors/DirectoryError.js';
-import FetchError from '~/errors/FetchError.js';
 
 describe('`parseImageParams()`', () => {
   const urlTest = 'https://picsum.photos/200/300';
@@ -235,16 +235,16 @@ describe('`download()`', () => {
 
   test('should throw an error if the URL is invalid', async () => {
     const url = 'invalid-url';
-    await expect(download(url)).rejects.toThrow(FetchError);
+    await expect(download(url)).rejects.toThrow(RequestError);
   });
 
   test('should throw an error if the response is unsuccessful', async () => {
     const url = 'https://picsum.photos/xxx';
-    await expect(download(url)).rejects.toThrow(FetchError);
+    await expect(download(url)).rejects.toThrow(HTTPError);
   });
 
   test('should throw an error if the response is not an image', async () => {
     const url = 'https://picsum.photos';
-    await expect(download(url)).rejects.toThrow(FetchError);
+    await expect(download(url)).rejects.toThrow(RequestError);
   });
 });


### PR DESCRIPTION
## Reason

Currently, we use the [`fetch API`](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API/Using_Fetch) to download images which can be too slow, especially if the image size is large or the destination server is too slow in responding.

## What Changes

Now, we use [**`got`** package](https://npmjs.org/packages/got) that provides [stream](https://github.com/sindresorhus/got/blob/main/documentation/3-streams.md) feature, so that both fetching (reading) and saving (writing) are streamed.

By default, `got` also [retries failed requests](https://github.com/sindresorhus/got/blob/main/documentation/7-retry.md) twice. To customize that, you can use **`maxRetry`** option (`--max-retry` for CLI).

We've also added a **`timeout`** option so you can limit how long the maximum time for a single request is.