### PR TITLE
Awaiting for `queue.add` in the wrong scope caused concurrency blocking

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -98,7 +98,7 @@ async function imgdl(url: string | string[], options?: Options): Promise<void> {
 
   const countNames = new Map<string, number>();
 
-  for (const _url of urls) {
+  urls.forEach(async (_url) => {
     const img = parseImageParams(_url, { directory, name, extension });
 
     // Make sure the name is unique
@@ -128,7 +128,7 @@ async function imgdl(url: string | string[], options?: Options): Promise<void> {
         _url,
       );
     }
-  }
+  });
 
   await queue.onIdle();
 }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

> Put `[x]` to check

- [x] I have read the documentation.
- [x] I have read and followed the Contributing Guidelines.
- [x] I have included a pull request description of my changes.
- [x] I have included the necessary changes to the documentation.
- [x] I have added tests to cover my changes.

## PR Type

What kind of change does this PR introduce?

> Please check any kind of changes that applies to this PR using `[x]`

- [x] Bug fix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

## What is the current behavior?

> Please describe the current behavior that you are modifying, or link to a relevant issue.

Issue Number: N/A

Awaiting for `queue.add` in the wrong scope caused concurrency blocking. The next job does not added to the queue until the current job is finished.

## What is the new behavior?

Replace `for...of` with `Array.forEach` callback. Now the job will be added without the need to wait for the previous job to be completed.

## Other information

None
