### PR TITLE
Fix missing `await` inside `download` function

### DIFF
--- a/src/downloader.ts
+++ b/src/downloader.ts
@@ -175,7 +175,7 @@ export async function download(img: Image, options: DownloadOptions = {}) {
     }
   }
 
-  return new Promise<Image>((resolve, reject) => {
+  return await new Promise<Image>((resolve, reject) => {
     const fetchStream = got.stream(img.url, {
       timeout: {
         request: options.timeout,


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

> Put `[x]` to check

- [x] I have read the documentation.
- [x] I have read and followed the Contributing Guidelines.
- [x] I have included a pull request description of my changes.
- [x] I have included the necessary changes to the documentation.
- [x] I have added tests to cover my changes.

## PR Type

What kind of change does this PR introduce?

> Please check any kind of changes that applies to this PR using `[x]`

- [x] Bug fix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] *..... (describe the other type)*

## What is the current behavior?

> Please describe the current behavior that you are modifying, or link to a relevant issue.

Issue Number: N/A

Failed CI tests before this is caused by unawaited promise in the `download` function. The queue in  `imgdl` function also not awaiting it, so that the `fs.access` test always throw 'unexists file' error.

## What is the new behavior?

Awaiting the promise directly in the `download` function.

## Other information

None