### PR TITLE
Add URL-level options, improve the Overwrite Prevention

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,37 @@ await imgdl(urls, {
 console.log('Download completed');
 ```
 
+#### Bulk download with specific options
+
+```js
+import imgdl from 'img-dl';
+
+const options = {
+  // Set default image options for all images
+  name: 'avatar',
+  extension: 'png',
+
+  // Another options
+  onSuccess: (image) => {
+    console.log(`Downloaded ${image.name}.${image.extension}`);
+  },
+  onError: (error, url) => {
+    console.error(`Failed to download ${url}: ${error.message}`);
+  },
+  timeout: 5000,
+};
+
+await imgdl(
+  // Provide array of URLs with specific options
+  [
+    { url: 'http://example.com/image.jpg', name: 'myavatar' }, // Will be saved as `myavatar.png`
+    { url: 'http://example.com/image.jpg', extension: 'webp' }, // Will be saved as `avatar.webp`
+    { url: 'http://example.com/image2.jpg', directory: 'avatars' }, // Will be saved as `avatar.png` in `avatars` directory
+  ],
+  options,
+);
+```
+
 ## API
 
 ### imgdl(url, ?options)
@@ -184,10 +215,17 @@ Download image(s) from the given URL(s).
 
 #### `url`
 
-Type: `string | string[]` <br>
+Type: `string | (string | ({ url: string } & ImageOptions))[]`<br>
 Required: `true`
 
 The URL(s) of the image(s) to download. Required.
+
+If the `url` is a string, it will download a single image.
+
+If the `url` is an array, it will download multiple images.
+
+- Each item in the array can be a URL in **string** or an **object** containing the URL and the image options.
+- This URL-level options **will override** the function-level options, the image options provided in the second argument (see [`options`](#options)).
 
 #### `options`
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

> Put `[x]` to check

- [x] I have read the documentation.
- [x] I have read and followed the Contributing Guidelines.
- [x] I have included a pull request description of my changes.
- [x] I have included the necessary changes to the documentation.
- [x] I have added tests to cover my changes.

## PR Type

What kind of change does this PR introduce?

> Please check any kind of changes that applies to this PR using `[x]`

- [ ] Bug fix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

## What is the current behavior?

> Please describe the current behavior that you are modifying, or link to a relevant issue.

Issue Number: #19 

- Add a feature to set a specific name, extension, or directory for each URL.
- The Overwrite Prevention doesn't consider the `directory` options.

## What is the new behavior?

- The `url` parameter of `imgdl` function now can retrieve an array that contains both `string` and `object` which contains the `url` and the specific image options.
- Improve the Overwrite Prevention to consider the `directory` options.

## Other information

None
