### PR TITLE
Fix CLI crash, Improving error handling

### DIFF
--- a/src/downloader.ts
+++ b/src/downloader.ts
@@ -99,10 +99,9 @@ export function parseImageParams(url: string, options?: ImageOptions) {
     path: '',
   };
 
-  // Validate the directory path syntax and ensure it is a directory without a filename.
-  const { base, name: nameFromPath } = path.parse(img.directory);
-  if (base !== nameFromPath) {
-    throw new ArgumentError('`directory` cannot contain filename');
+  // Ensure the directory doesn't contains file extension.
+  if (path.extname(img.directory) !== '') {
+    throw new ArgumentError('`directory` cannot contains file extension');
   }
 
   // Set name

--- a/src/index.ts
+++ b/src/index.ts
@@ -106,23 +106,24 @@ async function imgdl(
     const { url: imgUrl, ...imgOptions } =
       typeof _url === 'string' ? { url: _url } : _url;
 
-    const img = parseImageParams(imgUrl, {
-      directory: imgOptions.directory || directory,
-      name: imgOptions.name || name,
-      extension: imgOptions.extension || extension,
-    });
-
-    // Make sure the name is unique in the destination directory
-    const nameKey = `${img.directory}/${img.name}.${img.extension}`;
-    const count = countNames.get(nameKey);
-    if (count) {
-      img.name = `${img.name} (${count})`;
-      img.path = path.resolve(img.directory, `${img.name}.${img.extension}`);
-    }
-    countNames.set(nameKey, (count || 0) + 1);
-
-    // Add the download task to queue
     try {
+      // Validate and parse the image parameters
+      const img = parseImageParams(imgUrl, {
+        directory: imgOptions.directory || directory,
+        name: imgOptions.name || name,
+        extension: imgOptions.extension || extension,
+      });
+
+      // Make sure the name is unique in the destination directory
+      const nameKey = `${img.directory}/${img.name}.${img.extension}`;
+      const count = countNames.get(nameKey);
+      if (count) {
+        img.name = `${img.name} (${count})`;
+        img.path = path.resolve(img.directory, `${img.name}.${img.extension}`);
+      }
+      countNames.set(nameKey, (count || 0) + 1);
+
+      // Add the download task to queue
       const image = await queue.add(
         ({ signal }) => download(img, { ...downloadOptions, signal }),
         { signal: downloadOptions?.signal },
@@ -132,12 +133,7 @@ async function imgdl(
         onSuccess?.(image);
       }
     } catch (error) {
-      onError?.(
-        error instanceof Error
-          ? error
-          : new Error('Unknown error', { cause: error }),
-        imgUrl,
-      );
+      onError?.(error as Error, imgUrl);
     }
   });
 

--- a/test/cli.spec.ts
+++ b/test/cli.spec.ts
@@ -3,71 +3,97 @@ import { beforeAll, describe, expect, it } from 'vitest';
 
 describe('cli', () => {
   /**
+   * The build folder for the test
+   */
+  const dist = 'test/dist';
+  /**
    * A valid URL for testing.
    */
   const testUrl = 'http://example.com/image.webp';
 
   beforeAll(async () => {
-    await $`npm run build`;
+    await $`tsup src/cli.ts --format esm -d ${dist} --clean`;
   });
 
   it('should show the version', async () => {
-    const { exitCode, stdout } = await $`node dist/cli.js --version`;
+    const { exitCode, stdout } = await $`node ${dist}/cli.js --version`;
     expect(exitCode).toBe(0);
     expect(stdout).toMatch(/\d+\.\d+\.\d+/);
   });
 
   it('should show the version with short flag', async () => {
-    const { exitCode, stdout } = await $`node dist/cli.js -v`;
+    const { exitCode, stdout } = await $`node ${dist}/cli.js -v`;
     expect(exitCode).toBe(0);
     expect(stdout).toMatch(/\d+\.\d+\.\d+/);
   });
 
   it('should show the help message if no arguments are provided', async () => {
-    const { exitCode, stdout } = await $`node dist/cli.js`;
+    const { exitCode, stdout } = await $`node ${dist}/cli.js`;
     expect(exitCode).toBe(0);
     expect(stdout).contains('USAGE').contains('PARAMETERS').contains('OPTIONS');
   });
 
-  it('should throw an error if some arguments is invalid', async () => {
-    await expect(
-      $`node dist/cli.js ${testUrl} --name=invalid/name`,
-    ).rejects.toThrow();
-  });
-
   it('should throw an error if the directory cannot be created', async () => {
-    await expect($`node dist/cli.js ${testUrl} --dir=/root`).rejects.toThrow();
+    const { stderr } = await $`node ${dist}/cli.js ${testUrl} --dir=/root`;
+    expect(stderr).toContain('DirectoryError');
   });
 
-  it('should throw an error if the URL is invalid', async () => {
-    await expect($`node dist/cli.js invalid.url`).rejects.toThrow();
+  it('should throw an error if some arguments is invalid', async () => {
+    const { stderr } =
+      await $`node ${dist}/cli.js ${testUrl} --name=invalid/name`;
+
+    expect(stderr).toContain('ArgumentError');
   });
+
+  it.each([
+    'not-url',
+    'some/path',
+    'example.com/image.jpg',
+    'ftp://example.com',
+    'ws://example.com',
+  ])('should throw an error if URL is invalid: `%s`', async (url) => {
+    const { stderr } = await $`node ${dist}/cli.js ${url}`;
+    expect(stderr).toContain('ArgumentError');
+  });
+
+  it.each([
+    '',
+    'InvalidHeader NoColonValue',
+    'Empty-Value-Header:',
+    'Empty-Value-Header: ',
+    ': value',
+  ])(
+    'should throw an error if the header is not valid: `%s`',
+    async (header) => {
+      const { stderr } = await $`node ${dist}/cli.js ${testUrl} -H ${header}`;
+      expect(stderr).toContain('ArgumentError');
+    },
+  );
 
   describe('Increment mode', () => {
     const testUrl = 'http://example.com/image-{i}.webp';
 
     it('should throw an error if the end index is not specified', async () => {
-      await expect(
-        $`node dist/cli.js ${testUrl} --increment`,
-      ).rejects.toThrow();
+      const { stderr } = await $`node ${dist}/cli.js ${testUrl} --increment`;
+      expect(stderr).toContain('ArgumentError');
     });
 
     it('should throw an error if URL more than 1', async () => {
-      await expect(
-        $`node dist/cli.js ${testUrl} ${testUrl} --increment --end=10`,
-      ).rejects.toThrow();
+      const { stderr } =
+        await $`node ${dist}/cli.js ${testUrl} ${testUrl} --increment --end=10`;
+      expect(stderr).toContain('ArgumentError');
     });
 
     it('should throw an error if the start index is greater than the end index', async () => {
-      await expect(
-        $`node dist/cli.js ${testUrl} --increment --start=2 --end=1`,
-      ).rejects.toThrow();
+      const { stderr } =
+        await $`node ${dist}/cli.js ${testUrl} --increment --start=2 --end=1`;
+      expect(stderr).toContain('ArgumentError');
     });
 
     it('should throw an error if the URL does not contain the index placeholder', async () => {
-      await expect(
-        $`node dist/cli.js http://example.com/image.jpg --increment --end=10`,
-      ).rejects.toThrow();
+      const { stderr } =
+        await $`node ${dist}/cli.js http://example.com/image.jpg --increment --end=10`;
+      expect(stderr).toContain('ArgumentError');
     });
   });
 });

--- a/test/downloader.spec.ts
+++ b/test/downloader.spec.ts
@@ -230,11 +230,13 @@ describe('`download`', () => {
     await expect(fs.promises.access(image.path)).resolves.toBeUndefined();
   });
 
-  it('should throw an error if directory cannot be created', async () => {
-    const directory = '/restricted-dir';
-    const image = parseImageParams(`${BASE_URL}/image.jpg`, { directory });
-    await expect(download(image)).rejects.toThrow(DirectoryError);
-  });
+  it.each(['/root', '/restricted-dir'])(
+    'should throw an error if directory cannot be created: `%s`',
+    async (directory) => {
+      const image = parseImageParams(`${BASE_URL}/image.jpg`, { directory });
+      await expect(download(image)).rejects.toThrow(DirectoryError);
+    },
+  );
 
   it.for(['tmp', 'test/tmp'])(
     'should create the directory if it does not exist: `%s`',

--- a/test/downloader.spec.ts
+++ b/test/downloader.spec.ts
@@ -85,10 +85,13 @@ describe('parseImageParams', () => {
     'image.jpg',
     './image.jpg',
     './image.jpg/',
-  ])('should throw error if directory contains filename: `%s`', (directory) => {
-    const url = 'https://example.com/image.jpg';
-    expect(() => parseImageParams(url, { directory })).toThrow(ArgumentError);
-  });
+  ])(
+    'should throw error if directory contains file extension: `%s`',
+    (directory) => {
+      const url = 'https://example.com/image.jpg';
+      expect(() => parseImageParams(url, { directory })).toThrow(ArgumentError);
+    },
+  );
 
   it('should use original name if no name is provided', () => {
     const url = 'https://example.com/someimage.jpg';

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -15,6 +15,7 @@ import { BASE_URL } from './fixtures/mocks/handlers.js';
 import * as downloader from '~/downloader.js';
 import path from 'node:path';
 import DirectoryError from '~/errors/DirectoryError.js';
+import ArgumentError from '~/errors/ArgumentError.js';
 
 describe('`imgdl`', () => {
   /**
@@ -103,14 +104,23 @@ describe('`imgdl`', () => {
     expect(error).toBeInstanceOf(DirectoryError);
   });
 
-  it('should not throw any error if URL is invalid', async () => {
-    const url = `${BASE_URL}/unknown`;
+  it.each([
+    'not-url',
+    'some/path',
+    'example.com/image.jpg',
+    'ftp://example.com',
+    'ws://example.com',
+  ])('should not throw any error if URL is invalid', async (url) => {
+    let error: Error | undefined;
     const onSuccess = vi.fn();
-    const onError = vi.fn();
+    const onError = vi.fn().mockImplementation((err) => {
+      error = err;
+    });
 
     await expect(imgdl(url, { onSuccess, onError })).resolves.toBeUndefined();
     expect(onSuccess).toHaveBeenCalledTimes(0);
     expect(onError).toHaveBeenCalledTimes(1);
+    expect(error).toBeInstanceOf(ArgumentError);
   });
 
   it('should download multiple images if array of URLs is provided', async ({


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

> Put `[x]` to check

- [x] I have read the documentation.
- [x] I have read and followed the Contributing Guidelines.
- [x] I have included a pull request description of my changes.
- [x] I have included the necessary changes to the documentation.
- [x] I have added tests to cover my changes.

## PR Type

What kind of change does this PR introduce?

> Please check any kind of changes that applies to this PR using `[x]`

- [x] Bug fix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

## What is the current behavior?

> Please describe the current behavior that you are modifying, or link to a relevant issue.

Issue Number: N/A

- `imgdl` throws unexpected error when restricted directory is passed to `option.directory`.
- CLI crash when `imgdl` throws argument error or directory error.
- Unhandled `parseImageParams` error in imgdl.

## What is the new behavior?

- Ensure the directory is exists and unrestricted (e62c033f6183c2ffbd1d8c539b3d53f4f1e10849)
- Ensure `options.directory` does not contain file extension (e195e8ab80c3e6b310e4b2b81561f92ced0c904e)
- Fix unhandled `parseImageParams` error in imgdl (694deb92c79af5ae60fece3954d362cb6d0c4f44)

