### PR TITLE
fix CLI hang when `imgdl` throw error, set `--end` flag default

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ PARAMETERS
 
 OPTIONS
   -d, --dir=<path>          The output directory. Default: current working directory
-      --end=<number>        The end index. Required in increment mode
+      --end=<number>        The end index for increment mode. Default: 0
   -e, --ext=<ext>           The file extension. Default: original extension or jpg
   -h, --help                Show this help message
   -H, --header=<header>     The header to send with the request. Can be used multiple times

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -8,6 +8,7 @@ import chalk from 'chalk';
 import ArgumentError from './errors/ArgumentError.js';
 import DirectoryError from './errors/DirectoryError.js';
 import imgdl, { Options } from './index.js';
+import { generateDownloadUrls } from './utils.js';
 
 const cli = meow(
   `
@@ -21,7 +22,7 @@ const cli = meow(
 
   OPTIONS
     -d, --dir=<path>          The output directory. Default: current working directory
-        --end=<number>        The end index. Required in increment mode
+        --end=<number>        The end index for increment mode. Default: 0
     -e, --ext=<ext>           The file extension. Default: original extension or jpg
     -h, --help                Show this help message
     -H, --header=<header>     The header to send with the request. Can be used multiple times
@@ -104,8 +105,8 @@ const warningLog = chalk.yellow;
 const dimLog = chalk.dim;
 
 async function bootstrap() {
-  let urls = cli.input;
   const { flags } = cli;
+  const urls = generateDownloadUrls(cli.input, flags);
 
   if (flags.version) {
     cli.showVersion();
@@ -113,37 +114,6 @@ async function bootstrap() {
 
   if (!urls.length) {
     cli.showHelp(0);
-  }
-
-  if (flags.increment) {
-    if (urls.length > 1) {
-      throw new ArgumentError('Only one URL is allowed in increment mode');
-    }
-
-    const templateUrl = urls[0];
-
-    if (!templateUrl.includes('{i}')) {
-      throw new ArgumentError(
-        'The URL must contain {i} placeholder for the index',
-      );
-    }
-
-    if (!flags.end) {
-      throw new ArgumentError('The end index is required in increment mode');
-    }
-
-    if (flags.start && flags.start > flags.end) {
-      throw new ArgumentError(
-        'The start index cannot be greater than the end index',
-      );
-    }
-
-    const { start = 0, end } = flags;
-    urls = [];
-
-    for (let i = start; i <= end; i += 1) {
-      urls.push(templateUrl.replace('{i}', i.toString()));
-    }
   }
 
   if (!flags.silent) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,51 @@
+import ArgumentError from './errors/ArgumentError.js';
+
+type IncrementFlags = {
+  increment?: boolean;
+  start?: number;
+  end?: number;
+  name?: string;
+};
+
+/**
+ * Generate a list of URLs to be downloaded based on the flags.
+ * @throws {ArgumentError} If the urls or flags are invalid.
+ */
+export function generateDownloadUrls(
+  urls: string[],
+  flags: IncrementFlags,
+): string[] {
+  if (!flags.increment) {
+    return urls;
+  }
+
+  if (urls.length !== 1) {
+    throw new ArgumentError('Only one URL is allowed in increment mode');
+  }
+
+  if (!urls[0].includes('{i}')) {
+    throw new ArgumentError(
+      'The URL must contain {i} placeholder for the index',
+    );
+  }
+
+  const { start = 0, end = 0 } = flags;
+
+  if (start < 0) {
+    throw new ArgumentError('Start value must be greater than or equal to 0');
+  }
+
+  if (start > end) {
+    throw new ArgumentError(
+      'Start value must be less than or equal to end value',
+    );
+  }
+
+  const downloadUrls: string[] = [];
+
+  for (let i = start; i <= end; i += 1) {
+    downloadUrls.push(urls[0].replace('{i}', i.toString()));
+  }
+
+  return downloadUrls;
+}


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

> Put `[x]` to check

- [ ] I have read the documentation.
- [ ] I have read and followed the Contributing Guidelines.
- [ ] I have included a pull request description of my changes.
- [ ] I have included the necessary changes to the documentation.
- [ ] I have added tests to cover my changes.

## PR Type

What kind of change does this PR introduce?

> Please check any kind of changes that applies to this PR using `[x]`

- [x] Bug fix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

## What is the current behavior?

> Please describe the current behavior that you are modifying, or link to a relevant issue.

Issue Number: N/A

- PR #30 doesn't resolve the CLI hang properly.

## What is the new behavior?

- Use `try-finally` to handle `imgdl` error in CLI.
- Feat: `--end` flag now `0` by default.
