### PR TITLE
feat: CLI bulk download with file-input

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,11 +68,13 @@ Download image(s), by command or programmatically
 
 USAGE
   $ imgdl <url> ... [OPTIONS]
+  $ imgdl <path> [OPTIONS]
 
 PARAMETERS
   url   The URL of the image to download. Provide multiple URLs to download multiple images.
         In increment mode, the URL must contain {i} placeholder for the index,
         only one URL is allowed, and the '--end' is required.
+  path  The path to a local file that contains a list of image URLs.
 
 OPTIONS
   -d, --dir=<path>          The output directory. Default: current working directory
@@ -97,9 +99,9 @@ EXAMPLES
   $ imgdl https://example.com/image.jpg https://example.com/image2.webp
   $ imgdl https://example.com/image-{i}.jpg --increment --start=1 --end=10
   $ imgdl https://example.com/image.jpg --header="User-Agent: Mozilla/5.0" --header="Cookie: foo=bar"
-  $ imgdl /path/to/list.json
-  $ imgdl /path/to/list.csv
   $ imgdl /path/to/list.txt
+  $ imgdl /path/to/list.csv
+  $ imgdl /path/to/list.json
 ```
 
 #### Simple download
@@ -120,48 +122,60 @@ imgdl https://example.com/image.jpg https://example.com/image2.jpg
 imgdl https://example.com/image-{i}.jpg --increment --start=1 --end=10
 ```
 
-#### Download from file (JSON/CSV/TXT)
-
-- JSON array of URLs:
-
-```json
-[
-  "https://example.com/me/avatar.jpg",
-  "https://example.com/janedoe/avatar.jpg"
-]
-```
-
-- JSON array of objects with per-item options:
-
-```json
-[
-  { "url": "https://example.com/me/avatar.jpg", "directory": "myimages", "name": "myavatar", "extension": "png" },
-  { "url": "https://example.com/janedoe/avatar.jpg", "directory": "friends", "name": "janedoe" }
-]
-```
-
-- CSV with header (url,directory,name,extension):
-
-```csv
-url,directory,name,extension
-"https://example.com/me/avatar.jpg","myimages","myavatar","png"
-"https://example.com/janedoe/avatar.jpg","friends","janedoe",""
-```
+#### Download from file (TXT/CSV/JSON)
 
 - TXT (one URL per line):
 
-```text
-https://example.com/me/avatar.jpg
-https://example.com/janedoe/avatar.jpg
-```
+  ```text
+  https://example.com/me/avatar.jpg
+  https://example.com/janedoe/avatar.jpg
+  ```
+
+- CSV without header:
+
+  ```csv
+  "https://example.com/me/avatar.jpg","myimages","myavatar","png"
+  "https://example.com/janedoe/avatar.jpg","friends","janedoe",""
+  ```
+
+- CSV with header (url,directory,name,extension):
+
+  ```csv
+  url,directory,name,extension
+  "https://example.com/me/avatar.jpg",myimages,myavatar,png
+  "https://example.com/janedoe/avatar.jpg",friends,janedoe,jpg
+  "https://example.com/janedoe/avatar.jpg",,,webp
+  ```
+
+  > You don't need to include all columns, only the `url` column is required. The other columns are optional. Quotes are optional.
+
+- JSON array of URLs:
+
+  ```json
+  [
+    "https://example.com/me/avatar.jpg",
+    "https://example.com/janedoe/avatar.jpg"
+  ]
+  ```
+
+- JSON array of objects with per-item options:
+
+  ```json
+  [
+    { "url": "https://example.com/me/avatar.jpg", "directory": "myimages", "name": "myavatar", "extension": "png" },
+    { "url": "https://example.com/janedoe/avatar.jpg", "directory": "friends", "name": "janedoe" }
+  ]
+  ```
 
 Command examples:
 
 ```bash
+imgdl /path/to/list.txt --name=avatar
+imgdl /path/to/list.csv --dir=images --ext=png
 imgdl /path/to/list.json
-imgdl /path/to/list.csv
-imgdl /path/to/list.txt
 ```
+
+> **Note:** Any options specified in the input files will take precedence over the options specified in the command line.
 
 ### Programmatically
 

--- a/README.md
+++ b/README.md
@@ -97,6 +97,9 @@ EXAMPLES
   $ imgdl https://example.com/image.jpg https://example.com/image2.webp
   $ imgdl https://example.com/image-{i}.jpg --increment --start=1 --end=10
   $ imgdl https://example.com/image.jpg --header="User-Agent: Mozilla/5.0" --header="Cookie: foo=bar"
+  $ imgdl /path/to/list.json
+  $ imgdl /path/to/list.csv
+  $ imgdl /path/to/list.txt
 ```
 
 #### Simple download
@@ -115,6 +118,49 @@ imgdl https://example.com/image.jpg https://example.com/image2.jpg
 
 ```bash
 imgdl https://example.com/image-{i}.jpg --increment --start=1 --end=10
+```
+
+#### Download from file (JSON/CSV/TXT)
+
+- JSON array of URLs:
+
+```json
+[
+  "https://example.com/me/avatar.jpg",
+  "https://example.com/janedoe/avatar.jpg"
+]
+```
+
+- JSON array of objects with per-item options:
+
+```json
+[
+  { "url": "https://example.com/me/avatar.jpg", "directory": "myimages", "name": "myavatar", "extension": "png" },
+  { "url": "https://example.com/janedoe/avatar.jpg", "directory": "friends", "name": "janedoe" }
+]
+```
+
+- CSV with header (url,directory,name,extension):
+
+```csv
+url,directory,name,extension
+"https://example.com/me/avatar.jpg","myimages","myavatar","png"
+"https://example.com/janedoe/avatar.jpg","friends","janedoe",""
+```
+
+- TXT (one URL per line):
+
+```text
+https://example.com/me/avatar.jpg
+https://example.com/janedoe/avatar.jpg
+```
+
+Command examples:
+
+```bash
+imgdl /path/to/list.json
+imgdl /path/to/list.csv
+imgdl /path/to/list.txt
 ```
 
 ### Programmatically

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -13,15 +13,14 @@ import { generateDownloadUrls, isFilePath, parseFileInput } from './utils.js';
 const cli = meow(
   `
   USAGE
-    $ imgdl <url/path> ... [OPTIONS]
+    $ imgdl <url> ... [OPTIONS]
+    $ imgdl <path> [OPTIONS]
 
   PARAMETERS
-    url/path  The URL of the image to download or the path to a local file that
-              contains a list of images to download.
-              Provide multiple URLs to download multiple images.
-              In increment mode, the URL must contain {i} placeholder for the index,
-              only one URL is allowed, and the 'end' flag is required.
-              If path is provided, it must be a valid txt, csv, or json file.
+    url   The URL of the image to download. Provide multiple URLs to download multiple images.
+          In increment mode, the URL must contain {i} placeholder for the index,
+          only one URL is allowed, and the '--end' flag is required.
+    path  The path to a local file that contains a list of image URLs.
 
   OPTIONS
     -d, --dir=<path>          The output directory. Default: current working directory

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,3 +1,6 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import type { ImageOptions } from 'dist/index.js';
 import ArgumentError from './errors/ArgumentError.js';
 
 type IncrementFlags = {
@@ -48,4 +51,133 @@ export function generateDownloadUrls(
   }
 
   return downloadUrls;
+}
+
+export function isFilePath(p: string) {
+  try {
+    const stat = fs.statSync(path.resolve(p));
+    return stat.isFile();
+  } catch {
+    return false;
+  }
+}
+
+export function parseCsvLine(line: string): string[] {
+  const result: string[] = [];
+  let current = '';
+  let inQuotes = false;
+
+  for (let i = 0; i < line.length; i += 1) {
+    const char = line[i];
+
+    if (char === '"') {
+      if (inQuotes && line[i + 1] === '"') {
+        current += '"';
+        i += 1; // skip escaped quote
+      } else {
+        inQuotes = !inQuotes;
+      }
+    } else if (char === ',' && !inQuotes) {
+      result.push(current.trim());
+      current = '';
+    } else {
+      current += char;
+    }
+  }
+
+  result.push(current.trim());
+  return result.map((v) => v.replace(/^"|"$/g, ''));
+}
+
+export function parseFileInput(
+  filePath: string,
+): (string | ({ url: string } & ImageOptions))[] {
+  const fullPath = path.resolve(filePath);
+  const ext = path.extname(fullPath).toLowerCase();
+  const content = fs.readFileSync(fullPath, 'utf8');
+
+  if (ext === '.json') {
+    const data = JSON.parse(content);
+    if (!Array.isArray(data)) {
+      throw new ArgumentError('JSON file must contain an array');
+    }
+
+    return data.map((item) => {
+      if (typeof item === 'string') return item;
+      if (item && typeof item === 'object' && typeof item.url === 'string') {
+        const { url, directory, name, extension } = item as {
+          url: string;
+          directory?: string;
+          name?: string;
+          extension?: string;
+        };
+        const obj: { url: string } & ImageOptions = { url };
+        if (directory) obj.directory = directory;
+        if (name) obj.name = name;
+        if (extension) obj.extension = extension;
+        return obj;
+      }
+      throw new ArgumentError('Invalid JSON item format');
+    });
+  }
+
+  if (ext === '.csv') {
+    const lines = content
+      .split(/\r?\n/)
+      .map((l) => l.trim())
+      .filter((l) => l.length > 0);
+
+    if (lines.length === 0) return [];
+
+    const first = parseCsvLine(lines[0]);
+    const lower = first.map((h) => h.toLowerCase());
+    const hasHeader = lower.includes('url');
+
+    if (hasHeader) {
+      const colIndex = {
+        url: lower.indexOf('url'),
+        directory: lower.indexOf('directory'),
+        name: lower.indexOf('name'),
+        extension: lower.indexOf('extension'),
+      };
+      const rows = lines.slice(1);
+      const items: ({ url: string } & ImageOptions)[] = [];
+      for (const row of rows) {
+        const cols = parseCsvLine(row);
+        const url = cols[colIndex.url]?.trim();
+        if (!url) continue;
+        const entry: { url: string } & ImageOptions = { url };
+        const directory =
+          colIndex.directory >= 0
+            ? cols[colIndex.directory]?.trim()
+            : undefined;
+        const name =
+          colIndex.name >= 0 ? cols[colIndex.name]?.trim() : undefined;
+        const extension =
+          colIndex.extension >= 0
+            ? cols[colIndex.extension]?.trim()
+            : undefined;
+        if (directory) entry.directory = directory;
+        if (name) entry.name = name;
+        if (extension) entry.extension = extension;
+        items.push(entry);
+      }
+      return items;
+    }
+
+    // No header: treat as first column URLs
+    return lines
+      .map(parseCsvLine)
+      .map((cols) => cols[0]?.trim())
+      .filter((u): u is string => Boolean(u));
+  }
+
+  if (ext === '.txt') {
+    return content
+      .split(/\r?\n/)
+      .map((l) => l.trim())
+      .filter((l) => l.length > 0);
+  }
+
+  throw new ArgumentError('Unsupported file type');
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,7 +1,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import type { ImageOptions } from 'dist/index.js';
 import ArgumentError from './errors/ArgumentError.js';
+import type { ImageOptions } from './index.js';
 
 type IncrementFlags = {
   increment?: boolean;
@@ -86,7 +86,10 @@ export function parseCsvLine(line: string): string[] {
   }
 
   result.push(current.trim());
-  return result.map((v) => v.replace(/^"|"$/g, ''));
+
+  return result.map((v) =>
+    v.startsWith('"') && v.endsWith('"') && v.length >= 2 ? v.slice(1, -1) : v,
+  );
 }
 
 export function parseFileInput(

--- a/test/utils.spec.ts
+++ b/test/utils.spec.ts
@@ -1,0 +1,280 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { beforeEach, describe, expect, it } from 'vitest';
+import ArgumentError from '~/errors/ArgumentError.js';
+import {
+  generateDownloadUrls,
+  isFilePath,
+  parseCsvLine,
+  parseFileInput,
+} from '~/utils.js';
+import { TEST_TMP_DIR } from './helpers/paths.js';
+
+const TEST_UTILS_DIR = path.resolve(TEST_TMP_DIR, 'utils');
+
+beforeEach(async () => {
+  await fs.promises.rm(TEST_UTILS_DIR, { recursive: true, force: true });
+  await fs.promises.mkdir(TEST_UTILS_DIR, { recursive: true });
+});
+
+describe('isFilePath', () => {
+  it('should return true for existing file', async () => {
+    const filePath = path.join(TEST_UTILS_DIR, 'test.txt');
+    await fs.promises.writeFile(filePath, 'test content');
+
+    expect(isFilePath(filePath)).toBe(true);
+  });
+
+  it('should return false for non-existing file', () => {
+    const filePath = path.join(TEST_UTILS_DIR, 'non-existing.txt');
+    expect(isFilePath(filePath)).toBe(false);
+  });
+
+  it('should return false for directory', async () => {
+    const dirPath = path.join(TEST_UTILS_DIR, 'subdir');
+    await fs.promises.mkdir(dirPath);
+    expect(isFilePath(dirPath)).toBe(false);
+  });
+});
+
+describe('parseCsvLine', () => {
+  it('should parse simple CSV line', () => {
+    expect(parseCsvLine('a,b,c')).toEqual(['a', 'b', 'c']);
+  });
+
+  it('should parse CSV line with quotes', () => {
+    expect(parseCsvLine('"a","b","c"')).toEqual(['a', 'b', 'c']);
+  });
+
+  it('should parse CSV line with escaped quotes', () => {
+    expect(parseCsvLine('"a""b","c"')).toEqual(['a"b', 'c']);
+  });
+
+  it('should handle CSV line with commas inside quotes', () => {
+    expect(parseCsvLine('"a,b","c"')).toEqual(['a,b', 'c']);
+  });
+
+  it('should handle empty fields', () => {
+    expect(parseCsvLine('a,,c')).toEqual(['a', '', 'c']);
+  });
+
+  it('should handle whitespace around fields', () => {
+    expect(parseCsvLine(' a , b , c ')).toEqual(['a', 'b', 'c']);
+  });
+});
+
+describe('parseFileInput', () => {
+  describe('JSON files', () => {
+    it('should parse JSON array of URLs', async () => {
+      const filePath = path.join(TEST_UTILS_DIR, 'urls.json');
+      const data = ['http://example.com/1.jpg', 'http://example.com/2.jpg'];
+      await fs.promises.writeFile(filePath, JSON.stringify(data));
+
+      const result = parseFileInput(filePath);
+      expect(result).toEqual(data);
+    });
+
+    it('should parse JSON array of objects', async () => {
+      const filePath = path.join(TEST_UTILS_DIR, 'objects.json');
+      const data = [
+        { url: 'http://example.com/1.jpg', name: 'img1' },
+        {
+          url: 'http://example.com/2.jpg',
+          directory: 'images',
+          extension: 'png',
+        },
+      ];
+      await fs.promises.writeFile(filePath, JSON.stringify(data));
+
+      const result = parseFileInput(filePath);
+      expect(result).toEqual([
+        { url: 'http://example.com/1.jpg', name: 'img1' },
+        {
+          url: 'http://example.com/2.jpg',
+          directory: 'images',
+          extension: 'png',
+        },
+      ]);
+    });
+
+    it('should throw error for non-array JSON', async () => {
+      const filePath = path.join(TEST_UTILS_DIR, 'invalid.json');
+      await fs.promises.writeFile(filePath, JSON.stringify({ url: 'test' }));
+
+      expect(() => parseFileInput(filePath)).toThrow(ArgumentError);
+    });
+
+    it('should throw error for invalid JSON item format', async () => {
+      const filePath = path.join(TEST_UTILS_DIR, 'invalid-item.json');
+      const data = [{ notUrl: 'test' }];
+      await fs.promises.writeFile(filePath, JSON.stringify(data));
+
+      expect(() => parseFileInput(filePath)).toThrow(ArgumentError);
+    });
+  });
+
+  describe('CSV files', () => {
+    it('should parse CSV with header', async () => {
+      const filePath = path.join(TEST_UTILS_DIR, 'with-header.csv');
+      const csv = [
+        'url,name,extension',
+        'http://example.com/1.jpg,img1,png',
+        'http://example.com/2.jpg,img2,',
+      ].join('\n');
+      await fs.promises.writeFile(filePath, csv);
+
+      const result = parseFileInput(filePath);
+      expect(result).toEqual([
+        { url: 'http://example.com/1.jpg', name: 'img1', extension: 'png' },
+        { url: 'http://example.com/2.jpg', name: 'img2' },
+      ]);
+    });
+
+    it('should parse CSV without header (URLs only)', async () => {
+      const filePath = path.join(TEST_UTILS_DIR, 'no-header.csv');
+      const csv = ['http://example.com/1.jpg', 'http://example.com/2.jpg'].join(
+        '\n',
+      );
+      await fs.promises.writeFile(filePath, csv);
+
+      const result = parseFileInput(filePath);
+      expect(result).toEqual([
+        'http://example.com/1.jpg',
+        'http://example.com/2.jpg',
+      ]);
+    });
+
+    it('should handle empty CSV file', async () => {
+      const filePath = path.join(TEST_UTILS_DIR, 'empty.csv');
+      await fs.promises.writeFile(filePath, '');
+
+      const result = parseFileInput(filePath);
+      expect(result).toEqual([]);
+    });
+
+    it('should skip rows with empty URL', async () => {
+      const filePath = path.join(TEST_UTILS_DIR, 'skip-empty.csv');
+      const csv = [
+        'url,name',
+        'http://example.com/1.jpg,img1',
+        ',img2',
+        'http://example.com/3.jpg,img3',
+      ].join('\n');
+      await fs.promises.writeFile(filePath, csv);
+
+      const result = parseFileInput(filePath);
+      expect(result).toEqual([
+        { url: 'http://example.com/1.jpg', name: 'img1' },
+        { url: 'http://example.com/3.jpg', name: 'img3' },
+      ]);
+    });
+
+    it('should handle CSV with column index -1 (missing columns)', async () => {
+      const filePath = path.join(TEST_UTILS_DIR, 'missing-cols.csv');
+      const csv = [
+        'url', // only url column, no directory/name/extension
+        'http://example.com/1.jpg',
+        'http://example.com/2.jpg',
+      ].join('\n');
+      await fs.promises.writeFile(filePath, csv);
+
+      const result = parseFileInput(filePath);
+      expect(result).toEqual([
+        { url: 'http://example.com/1.jpg' },
+        { url: 'http://example.com/2.jpg' },
+      ]);
+    });
+  });
+
+  describe('TXT files', () => {
+    it('should parse TXT file with URLs per line', async () => {
+      const filePath = path.join(TEST_UTILS_DIR, 'urls.txt');
+      const txt = [
+        'http://example.com/1.jpg',
+        'http://example.com/2.jpg',
+        '', // empty line should be filtered
+      ].join('\n');
+      await fs.promises.writeFile(filePath, txt);
+
+      const result = parseFileInput(filePath);
+      expect(result).toEqual([
+        'http://example.com/1.jpg',
+        'http://example.com/2.jpg',
+      ]);
+    });
+
+    it('should handle empty TXT file', async () => {
+      const filePath = path.join(TEST_UTILS_DIR, 'empty.txt');
+      await fs.promises.writeFile(filePath, '');
+
+      const result = parseFileInput(filePath);
+      expect(result).toEqual([]);
+    });
+  });
+
+  it('should throw error for unsupported file type', async () => {
+    const filePath = path.join(TEST_UTILS_DIR, 'test.xml');
+    await fs.promises.writeFile(filePath, '<xml></xml>');
+
+    expect(() => parseFileInput(filePath)).toThrow(ArgumentError);
+  });
+});
+
+describe('generateDownloadUrls', () => {
+  it('should return the same URLs if increment flag is not set', () => {
+    const urls = ['http://example.com/1.jpg', 'http://example.com/2.jpg'];
+    const flags = {};
+
+    expect(generateDownloadUrls(urls, flags)).toEqual(urls);
+  });
+
+  it('should throw error if multiple URLs are provided in increment mode', () => {
+    const urls = ['http://example.com/1.jpg', 'http://example.com/2.jpg'];
+    const flags = { increment: true };
+
+    expect(() => generateDownloadUrls(urls, flags)).toThrow(ArgumentError);
+  });
+
+  it('should throw error if URL does not contain {i} placeholder', () => {
+    const urls = ['http://example.com/image.jpg'];
+    const flags = { increment: true };
+
+    expect(() => generateDownloadUrls(urls, flags)).toThrow(ArgumentError);
+  });
+
+  it('should throw error if start is less than 0', () => {
+    const urls = ['http://example.com/image{i}.jpg'];
+    const flags = { increment: true, start: -1 };
+
+    expect(() => generateDownloadUrls(urls, flags)).toThrow(ArgumentError);
+  });
+
+  it('should throw error if start is greater than end', () => {
+    const urls = ['http://example.com/image{i}.jpg'];
+    const flags = { increment: true, start: 5, end: 3 };
+
+    expect(() => generateDownloadUrls(urls, flags)).toThrow(ArgumentError);
+  });
+
+  it('should generate URLs correctly with increment mode', () => {
+    const urls = ['http://example.com/image{i}.jpg'];
+    const flags = { increment: true, start: 1, end: 3 };
+
+    expect(generateDownloadUrls(urls, flags)).toEqual([
+      'http://example.com/image1.jpg',
+      'http://example.com/image2.jpg',
+      'http://example.com/image3.jpg',
+    ]);
+  });
+
+  it('should use default start (0) when not specified', () => {
+    const urls = ['http://example.com/image{i}.jpg'];
+    const flags = { increment: true, end: 2 };
+
+    expect(generateDownloadUrls(urls, flags)).toEqual([
+      'http://example.com/image0.jpg',
+      'http://example.com/image1.jpg',
+      'http://example.com/image2.jpg',
+    ]);
+  });
+});


### PR DESCRIPTION
This branch adds support for downloading from file inputs (JSON/CSV/TXT) in the CLI, tightens several test assertions to be deterministic, and introduces new unit tests for utils to increase coverage.

Changes include:
- CLI: Accept file paths as input and parse JSON/CSV/TXT files (see `src/cli.ts`).
- Utils: Add `isFilePath`, `parseCsvLine`, and `parseFileInput` to `src/utils.ts` (and corresponding logic to parse JSON/CSV/TXT files).
- Tests: Replace brittle `.some(...endsWith('.jpg'))` assertions with explicit counts where appropriate in `test/cli.spec.ts`.
- Tests: Add `test/utils.spec.ts` to cover `isFilePath`, `parseCsvLine`, `parseFileInput`, and extend `generateDownloadUrls` tests.

This will resolve #93.